### PR TITLE
Add missing return values in commands

### DIFF
--- a/Command/DriverLockCommand.php
+++ b/Command/DriverLockCommand.php
@@ -66,7 +66,8 @@ EOT
         if ($input->isInteractive()) {
             if (!$this->askConfirmation('WARNING! Are you sure you wish to continue? (y/n)', $input, $output)) {
                 $output->writeln('<error>Maintenance cancelled!</error>');
-                return;
+
+                return Command::FAILURE;
             }
         } elseif (null !== $input->getArgument('ttl')) {
             $this->ttl = $input->getArgument('ttl');
@@ -80,6 +81,8 @@ EOT
         }
 
         $output->writeln('<info>'.$driver->getMessageLock($driver->lock()).'</info>');
+
+        return Command::SUCCESS;
     }
 
     /**

--- a/Command/DriverLockCommand.php
+++ b/Command/DriverLockCommand.php
@@ -67,7 +67,7 @@ EOT
             if (!$this->askConfirmation('WARNING! Are you sure you wish to continue? (y/n)', $input, $output)) {
                 $output->writeln('<error>Maintenance cancelled!</error>');
 
-                return Command::FAILURE;
+                return 1;
             }
         } elseif (null !== $input->getArgument('ttl')) {
             $this->ttl = $input->getArgument('ttl');
@@ -82,7 +82,7 @@ EOT
 
         $output->writeln('<info>'.$driver->getMessageLock($driver->lock()).'</info>');
 
-        return Command::SUCCESS;
+        return 0;
     }
 
     /**

--- a/Command/DriverUnlockCommand.php
+++ b/Command/DriverUnlockCommand.php
@@ -46,7 +46,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (!$this->confirmUnlock($input, $output)) {
-            return Command::FAILURE;
+            return 1;
         }
 
         $driver = $this->driverFactory->getDriver();
@@ -55,7 +55,7 @@ EOT
 
         $output->writeln('<info>'.$unlockMessage.'</info>');
 
-        return Command::SUCCESS;
+        return 0;
     }
 
     /**

--- a/Command/DriverUnlockCommand.php
+++ b/Command/DriverUnlockCommand.php
@@ -46,7 +46,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (!$this->confirmUnlock($input, $output)) {
-            return;
+            return Command::FAILURE;
         }
 
         $driver = $this->driverFactory->getDriver();
@@ -54,6 +54,8 @@ EOT
         $unlockMessage = $driver->getMessageUnlock($driver->unlock());
 
         $output->writeln('<info>'.$unlockMessage.'</info>');
+
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
This is needed for Symfony 5 compatibility. Otherwise you would receive the following when running `lexik:maintenance:lock` / `lexik:maintenance:lock`:

```
Return value of "Lexik\Bundle\MaintenanceBundle\Command\DriverLockCommand::execute()" must be of the type int, "null" returned. 

Return value of "Lexik\Bundle\MaintenanceBundle\Command\DriverUnlockCommand::execute()" must be of the type int, "null" returned. 
```